### PR TITLE
Use an environment variable to find plugins

### DIFF
--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -34,13 +34,19 @@ QList<QButtonGroup*> PluginManager::reduceGetOptions(const QString &actionID)
 void PluginManager::load()
 {
 
-    QDir dir("/usr/lib/polkit-1-dde/plugins/");
-    QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
+    QStringList pluginsDirs = QProcessEnvironment::systemEnvironment().value("DDE_POLKIT_AGENT_PLUGINS_DIRS").split(QDir::listSeparator(), QString::SkipEmptyParts);
+    pluginsDirs.append("/usr/lib/polkit-1-dde/plugins/");
 
-    for (const QFileInfo &pluginFile : pluginFiles) {
-       AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
-       if (plugin)
-           m_plugins << plugin;
+    for (const QString &dirName : pluginsDirs) {
+        QDir dir(dirName);
+
+        QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
+
+        for (const QFileInfo &pluginFile : pluginFiles) {
+            AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
+            if (plugin)
+                m_plugins << plugin;
+        }
     }
 }
 


### PR DESCRIPTION
I am packaging the Deepin Desktop Environment for the [NixOS](https://nixos.org/) linux distribution. In NixOS each package is installed in its own directory structure (it does not follow FHS). Therefore two or more packages cannot share a directory.

Currently `dde-polkit-agent` looks for plugins in a unique hard coded directory. This PR enables it to look for plugins in several directories, given by an environment variable. This will help packaging it for NixOS.