### PR TITLE
fix: 连续点击确认按钮后退出鉴权

### DIFF
--- a/AuthDialog.cpp
+++ b/AuthDialog.cpp
@@ -48,6 +48,7 @@ AuthDialog::AuthDialog(const QString &message,
     , m_passwordInput(new DPasswordEdit(this))
     , m_numTries(0)
     , m_lockLimitTryNum(getLockLimitTryNum())
+    , m_authStatus(AuthStatus::None)
 {
     initUI();
 
@@ -358,11 +359,17 @@ void AuthDialog::initUI()
     });
 
     connect(m_passwordInput, &DPasswordEdit::textChanged, [ = ](const QString & text) {
-        getButton(confirmId)->setEnabled(text.length() > 0);
+        getButton(confirmId)->setEnabled(text.length() > 0 && Authenticating != m_authStatus && None != m_authStatus);
         if (text.length() == 0)
             return;
 
         m_passwordInput->setAlert(false);
         m_errorMsg = "";
     });
+}
+
+void AuthDialog::setInAuth(AuthStatus authStatus)
+{
+    m_authStatus = authStatus;
+    getButton(1)->setEnabled(Authenticating != authStatus && m_passwordInput->text().length() > 0);
 }

--- a/AuthDialog.h
+++ b/AuthDialog.h
@@ -48,6 +48,13 @@ public:
         Password = 1
     };
 
+    enum AuthStatus {
+        None = -1,
+        WaitingInput,
+        Authenticating,
+        Completed,
+    };
+
     AuthDialog(const QString &message,
                const QString &iconName);
     ~AuthDialog();
@@ -68,6 +75,8 @@ public:
 
     bool hasOpenSecurity();
     bool hasSecurityHighLever(QString userName);
+    void setInAuth(AuthStatus authStatus);
+
 signals:
     void adminUserSelected(PolkitQt1::Identity);
 
@@ -94,5 +103,6 @@ private:
     void showErrorTip();
 
     QString m_errorMsg;
+    AuthStatus m_authStatus;
 };
 #endif // AUTHDIALOG_H

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dde-polkit-agent (1.0-1) unstable; urgency=medium
+dde-polkit-agent (1.0) unstable; urgency=medium
 
   * Initial release
 

--- a/policykitlistener.cpp
+++ b/policykitlistener.cpp
@@ -183,9 +183,10 @@ void PolicyKitListener::request(const QString &request, bool echo)
 
     qDebug() << "session request: " << request;
 
-    if (m_dialog && !request.isEmpty())
+    if (m_dialog && !request.isEmpty()) {
         m_dialog.data()->setAuthInfo(request);
-
+        m_dialog.data()->setInAuth(AuthDialog::WaitingInput);
+    }
 }
 
 void PolicyKitListener::completed(bool gainedAuthorization)
@@ -203,6 +204,7 @@ void PolicyKitListener::completed(bool gainedAuthorization)
     }
 #endif
     finishObtainPrivilege();
+    m_dialog.data()->setInAuth(AuthDialog::Completed);
 }
 
 void PolicyKitListener::showError(const QString &text)
@@ -248,6 +250,7 @@ void PolicyKitListener::exAuthInfo(bool isMfa, QList<int> &authTypes) {
 
 void PolicyKitListener::dialogAccepted()
 {
+    m_dialog.data()->setInAuth(AuthDialog::Authenticating);
     m_session->setResponse(m_dialog->password());
 }
 


### PR DESCRIPTION
开始验证后禁用确认按钮，验证完成后再启用。

Log: 修复连续点击确认按钮后退出鉴权的问题
Bug: https://pms.uniontech.com/bug-view-131591.html
Influence: 输入错误密码的场景
Change-Id: I3f7ec05f5ff97110627dc9158e20b1266e67d9f6