### PR TITLE
chore: use CMAKE_SYSTEM_PROCESSOR to check sw_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=address -O2")
 endif()
 
-if (DEFINED ENABLE_MIEEE)
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
 endif()
 


### PR DESCRIPTION
ENABLE_MIEEE 是过时的写法，已经没有在用了（ 另外比较新的 swgcc 应该是默认带 -mieee 参数了
类似：https://github.com/linuxdeepin/dde-dock/pull/681