### PR TITLE
feat: 密码保险箱优化

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Homepage: http://www.deepin.org/
 
 Package: dde-polkit-agent
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dpa-ext-gnomekeyring
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: PolicyKit agent for DDE.
  PolicyKit agent is usually a dialog used to provide a way to let users
  grant permission to specific actions, this package serves the role in

--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -47,6 +47,10 @@ void PluginManager::load()
         QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
 
         for (const QFileInfo &pluginFile : pluginFiles) {
+            // 密钥环优化后，在keyring PAM中对keyring密码进行管理，不需要加载libdpa-ext-gnomekeyring来清空密钥环
+            if (pluginFile.baseName() == "libdpa-ext-gnomekeyring")
+                continue;
+
             AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
             if (plugin)
                 m_plugins << plugin;


### PR DESCRIPTION
生物认证登录解锁keyring，在keyring PAM中对keyring密码进行管理，不再需要清空密钥环

Log: 密码保险箱优化
Task: https://pms.uniontech.com/zentao/task-view-86321.html
Influence: 授权弹窗中“清空密钥环”插件显示
Change-Id: I98b905b692cac21abadbd834a5aacc5d6a31e44c