### PR TITLE
chore: filter dpa-ext-gnomekeyring and cancel pre installation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Homepage: http://www.deepin.org/
 
 Package: dde-polkit-agent
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dpa-ext-gnomekeyring,
+Depends: ${shlibs:Depends}, ${misc:Depends},
 Description: PolicyKit agent for DDE.
  PolicyKit agent is usually a dialog used to provide a way to let users
  grant permission to specific actions, this package serves the role in

--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -47,6 +47,9 @@ void PluginManager::load()
         QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
 
         for (const QFileInfo &pluginFile : pluginFiles) {
+            // dpa-ext-gnonekeyring 项目暂时无实质作用，如果安装过 dpa-ext-gnonekeyring 包, 进行一个过滤。
+            if (pluginFile.fileName() == "libdpa-ext-gnomekeyring.so") continue;
+
             AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
             if (plugin)
                 m_plugins << plugin;


### PR DESCRIPTION
对 libdpa-ext-gnomekeyring  进行过滤，dpa 项目目前可能没有其他作用，之前进行了预装先暂时屏蔽该插件。

Log: filter dpa-ext-gnomekeyring
Issue: https://github.com/linuxdeepin/developer-center/issues/5380