### PR TITLE
fix: qt warning about obsolete usage of QString::SkipEmptyParts

### DIFF
--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -38,7 +38,7 @@ QList<QButtonGroup*> PluginManager::reduceGetOptions(const QString &actionID)
 void PluginManager::load()
 {
 
-    QStringList pluginsDirs = QProcessEnvironment::systemEnvironment().value("DDE_POLKIT_AGENT_PLUGINS_DIRS").split(QDir::listSeparator(), QString::SkipEmptyParts);
+    QStringList pluginsDirs = QProcessEnvironment::systemEnvironment().value("DDE_POLKIT_AGENT_PLUGINS_DIRS").split(QDir::listSeparator(), Qt::SkipEmptyParts);
     pluginsDirs.append("/usr/lib/polkit-1-dde/plugins/");
 
     for (const QString &dirName : pluginsDirs) {


### PR DESCRIPTION
Use Qt::SkipEmptyParts instead.

Fixes the following warning:
```
/build/deepin-polkit-agent/src/dde-polkit-agent-6.0.5/pluginmanager.cpp:
In member function ‘void PluginManager::load()’:
/build/deepin-polkit-agent/src/dde-polkit-agent-6.0.5/pluginmanager.cpp:41:116:
warning: ‘QStringList QString::split(QChar, SplitBehavior,
Qt::CaseSensitivity) const’ is deprecated: Use split(QChar sep,
Qt::SplitBehavior ...) variant instead [-Wdeprecated-declarations]
   41 |     QStringList pluginsDirs =
      QProcessEnvironment::systemEnvironment().value("DDE_POLKIT_AGENT_PLUGINS_DIRS").split(QDir::listSeparator(),
      QString::SkipEmptyParts)
```