### PR TITLE
fix: Support always on top under Wayland by Layershell

### DIFF
--- a/AuthDialog.cpp
+++ b/AuthDialog.cpp
@@ -15,6 +15,7 @@
 #include <DIcon>
 
 #include <libintl.h>
+#include <dde-shell/dlayershellwindow.h>
 
 DWIDGET_USE_NAMESPACE
 
@@ -295,8 +296,16 @@ bool AuthDialog::event(QEvent *event)
 
 void AuthDialog::initUI()
 {
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
-    setWindowFlag(Qt::BypassWindowManagerHint, true);
+    // create window
+    winId();
+    auto wnd = windowHandle();
+    if (wnd) {
+        auto layerShellWnd = ds::DLayerShellWindow::get(wnd);
+        layerShellWnd->setLayer(ds::DLayerShellWindow::LayerTop);
+        layerShellWnd->setKeyboardInteractivity(ds::DLayerShellWindow::KeyboardInteractivityOnDemand);
+    } else {
+        qDebug() << "WindowHandle is null!!!";
+    }
     setMinimumWidth(380);
     setOnButtonClickedClose(false);
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ include(GNUInstallDirs)
 find_package(PkgConfig REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Widgets DBus Concurrent LinguistTools)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Widget Core Tools)
+find_package(DDEShell REQUIRED)
 
 pkg_check_modules(Polkit-qt6 REQUIRED polkit-qt6-1)
 
@@ -81,6 +82,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::Concurrent
+    Dde::Shell
     ${Polkit-qt6_LIBRARIES}
 )
 

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper (>=9),
 	qt6-tools-dev,
 	qt6-tools-dev-tools,
 	libdtk6core-bin,
+	libdde-shell-dev,
 	lsb-release
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org/


### PR DESCRIPTION
Switch to Layershell for window
Drop Qt::WindowStaysOnTopHint flag for Layershell will set this flag onX11 for the dialog

pms: BUG-291611
Log: Support always on top under Wayland by Layershell