### PR TITLE
feat: decouple from the proprietary component DA

### DIFF
--- a/tests/polkit.cc
+++ b/tests/polkit.cc
@@ -11,8 +11,11 @@ int main(int argc, char* argv[])
     const QString                  cookie;
     PolkitQt1::Agent::AsyncResult* result  = nullptr;
     PolkitQt1::Details*            details = nullptr;
+#ifdef USE_DEEPIN_POLKIT
     auto session = new PolkitQt1::Agent::Session(identity, cookie, result, details);
-
+#else
+    auto session = new PolkitQt1::Agent::Session(identity, cookie, result);
+#endif
     session->authCtrl(AUTH_START, -1);
     session->setResponseEx(0, cookie);
 


### PR DESCRIPTION
Log: 解耦DA组件

## Summary by Sourcery

Isolate and conditionally compile deepin-specific Polkit (DA) logic behind a new USE_DEEPIN_POLKIT flag to remove dependency on the proprietary component.

Enhancements:
- Guard deepin Polkit authentication failure handling and account lock checks with USE_DEEPIN_POLKIT macro
- Adjust Session constructor overload selection for deepin integration under the compile-time flag

Tests:
- Update Polkit session tests to use the conditional Session constructor signature when USE_DEEPIN_POLKIT is enabled