### PR TITLE
refactor: update build flags and security hardening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,17 +9,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_FLAGS "-g -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 
 option(USE_DEEPIN_POLKIT "enable deepin polkit" OFF)
 
 message(STATUS "TO USE Deepin_Polkit : ${USE_DEEPIN_POLKIT}")
 
-# 增加安全编译参数
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=address -O2")

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,10 @@
 #!/usr/bin/make -f
 
 export QT_SELECT=5
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 DISTRO = $(shell lsb_release -is)
 ifeq ($(DISTRO),Deepin)


### PR DESCRIPTION
1. Modified CMakeLists.txt to append flags instead of overwriting them
2. Removed redundant security flags that are now handled by debian/rules
3. Added comprehensive hardening flags in debian/rules including:
   - Relocation Read-Only (RELRO)
   - Immediate binding (NOW)
   - No executable stack
   - Export dynamic symbols (-E)
4. Enabled all hardening options through DEB_BUILD_MAINT_OPTIONS

These changes improve build consistency and security by:
- Preventing flag conflicts between CMake and Debian build system
- Centralizing security hardening in the Debian build configuration
- Maintaining existing debug capabilities while adding production security

refactor: 更新构建标志和安全加固

1. 修改 CMakeLists.txt 以追加标志而非覆盖
2. 移除现在由 debian/rules 处理的冗余安全标志
3. 在 debian/rules 中添加全面的加固标志包括：
   - 重定位只读(RELRO)
   - 立即绑定(NOW)
   - 无可执行栈
   - 导出动态符号(-E)
4. 通过 DEB_BUILD_MAINT_OPTIONS 启用所有加固选项

这些改进通过以下方式提升了构建一致性和安全性：
- 防止 CMake 和 Debian 构建系统之间的标志冲突
- 将安全加固集中配置在 Debian 构建配置中
- 在添加生产环境安全性的同时保留现有调试能力

## Summary by Sourcery

Refactor build configuration to append existing flags and centralize security hardening in the Debian build rules, improving build consistency and production security while retaining debug support.

Enhancements:
- Add comprehensive security hardening flags (RELRO, NOW, noexecstack, -E) to debian/rules
- Enable all Debian build hardening options via DEB_BUILD_MAINT_OPTIONS

Build:
- Modify CMakeLists.txt to append compiler flags instead of overwriting and remove redundant security flags