### PR TITLE
chore: bump version to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-polkit-agent (6.0.14) unstable; urgency=medium
+
+  * refactor: update build flags and security hardening
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 20:28:51 +0800
+
 dde-polkit-agent (6.0.13) unstable; urgency=medium
 
   * feat: decouple from the proprietary component DA


### PR DESCRIPTION
update changelog to 6.0.14

## Summary by Sourcery

Chores:
- Update debian/changelog entry to version 6.0.14