### PR TITLE
fix: Modify the status of the authorization dialog box button

### DIFF
--- a/AuthDialog.cpp
+++ b/AuthDialog.cpp
@@ -277,7 +277,10 @@ void AuthDialog::authenticationFailure(bool &isLock)
     m_passwordInput->setAlert(true);
     m_passwordInput->clear();
     m_passwordInput->lineEdit()->setFocus();
-    getButton(1)->setEnabled(true);
+    const bool enable = (m_authStatus != Authenticating
+                         && m_authStatus != None
+                         && !m_passwordInput->text().isEmpty());
+    getButton(1)->setEnabled(enable);
 
     if (isLock) {
         lock();
@@ -328,7 +331,7 @@ void AuthDialog::initUI()
     int confirmId = addButton(tr("Confirm", "button"), true, ButtonType::ButtonRecommend);
     setDefaultButton(1);
 
-    getButton(confirmId)->setEnabled(true);
+    getButton(confirmId)->setEnabled(false);
 
     getButton(cancelId)->setAccessibleName("Cancel");
     getButton(confirmId)->setAccessibleName("Confirm");
@@ -358,17 +361,20 @@ void AuthDialog::initUI()
     });
 
     connect(m_passwordInput, &DPasswordEdit::textChanged, [ = ](const QString & text) {
-        getButton(confirmId)->setEnabled(Authenticating != m_authStatus && None != m_authStatus);
-        if (text.length() == 0)
-            return;
+        getButton(confirmId)->setEnabled(Authenticating != m_authStatus && None != m_authStatus && text.length() > 0);
 
-        m_passwordInput->setAlert(false);
-        m_errorMsg = "";
+        if (text.length() > 0) {
+            m_passwordInput->setAlert(false);
+            m_errorMsg = "";
+        }
     });
 }
 
 void AuthDialog::setInAuth(AuthStatus authStatus)
 {
     m_authStatus = authStatus;
-    getButton(1)->setEnabled(Authenticating != authStatus);
+    const bool enable = (authStatus != Authenticating
+                         && authStatus != None
+                         && !m_passwordInput->text().isEmpty());
+    getButton(1)->setEnabled(enable);
 }

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,8 @@ ifeq ($(DISTRO),Deepin)
 	USE_DEEPIN_POLKIT=ON
 else ifeq ($(DISTRO),uos)
     USE_DEEPIN_POLKIT=ON
+else ifeq ($(DISTRO),Uos)
+    USE_DEEPIN_POLKIT=ON
 else
 	USE_DEEPIN_POLKIT=OFF
 endif


### PR DESCRIPTION
Modify the status of the authorization dialog box button

Log: Modify the status of the authorization dialog box button
pms: BUG-311143

## Summary by Sourcery

Refine the confirm button logic in the authorization dialog to prevent incorrect enabling by disabling it by default and only enabling when authentication status is valid and the password field is not empty.

Bug Fixes:
- Fix confirm button to only enable when auth status is not Authenticating or None and password input is non-empty in authenticationFailure and setInAuth
- Restrict enabling of the confirm button on text change to when auth status is valid and text length is greater than zero

Enhancements:
- Disable the confirm button by default during dialog initialization
- Only clear password field alerts and error messages when the input contains text