### PR TITLE
chore: bump version to 6.0.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-polkit-agent (6.0.15) unstable; urgency=medium
+
+  * fix: Modify the status of the authorization dialog box button
+  * fix: update homepage url in debian/control
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:01:55 +0800
+
 dde-polkit-agent (6.0.14) unstable; urgency=medium
 
   * refactor: update build flags and security hardening


### PR DESCRIPTION
update changelog to 6.0.15

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 6.0.15