### PR TITLE
fix: Fix the password error not selected completely

### DIFF
--- a/AuthDialog.cpp
+++ b/AuthDialog.cpp
@@ -275,8 +275,8 @@ void AuthDialog::authenticationFailure(bool &isLock)
     m_passwordInput->setEnabled(true);
     m_passwordInput->showAlertMessage(m_errorMsg);
     m_passwordInput->setAlert(true);
-    m_passwordInput->clear();
     m_passwordInput->lineEdit()->setFocus();
+    m_passwordInput->lineEdit()->selectAll();
     const bool enable = (m_authStatus != Authenticating
                          && m_authStatus != None
                          && !m_passwordInput->text().isEmpty());


### PR DESCRIPTION
Fix the password error not selected completely

Log: Fix the password error not selected completely
pms: BUG-311135

## Summary by Sourcery

Bug Fixes:
- Select all text in the password input on authentication failure instead of clearing it to ensure the error is fully highlighted