### PR TITLE
chore: bump version to 6.0.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-polkit-agent (6.0.16) unstable; urgency=medium
+
+  * refactor: remove fingerprint authentication related files
+  * fix: Fix the password error not selected completely
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 25 Sep 2025 20:52:29 +0800
+
 dde-polkit-agent (6.0.15) unstable; urgency=medium
 
   * fix: Modify the status of the authorization dialog box button


### PR DESCRIPTION
update changelog to 6.0.16

## Summary by Sourcery

Bump project version to 6.0.16 and update the Debian changelog accordingly.

Chores:
- Update Debian changelog for version 6.0.16
- Bump project version to 6.0.16