### PR TITLE
fix: prevent polkit auth dialog from being permanently blocked after …

### DIFF
--- a/policykitlistener.cpp
+++ b/policykitlistener.cpp
@@ -236,12 +236,19 @@ void PolicyKitListener::exAuthInfo(bool isMfa, QList<int> &authTypes) {
 
 void PolicyKitListener::dialogAccepted()
 {
+    if (!m_inProgress || m_session.isNull() || m_dialog.isNull())
+        return;
+
     m_dialog.data()->setInAuth(AuthDialog::Authenticating);
     m_session->setResponse(m_dialog->password());
 }
 
 void PolicyKitListener::dialogCanceled()
 {
+    if (!m_inProgress)
+        return;
+
+    qDebug() << "PolicyKitListener::dialogCanceled()";
     m_inProgress = false;
     m_wasCancelled = true;
 
@@ -262,8 +269,12 @@ void PolicyKitListener::dialogCanceled()
 
 void PolicyKitListener::dialogFinished(int result)
 {
-    // 处理其他方式关闭对话框的情况
-    if (result != QDialog::Accepted && result != QDialog::Rejected) {
+    Q_UNUSED(result);
+    // 确保对话框关闭时清理状态
+    // 修复：当用户通过标题栏关闭按钮(X)关闭对话框时，
+    // DDialog::closeEvent 使用残留的 clickedButtonIndex 调用 done()，
+    // 可能导致触发 accepted() 而非 rejected()，使 m_inProgress 卡死为 true
+    if (m_inProgress) {
         dialogCanceled();
     }
 }


### PR DESCRIPTION
…locked dismissal

Problem:
After entering wrong passwords until the account is locked, closing the polkit dialog via the title bar close button (X) prevents the auth dialog from ever reopening on subsequent authentication requests.

Root Cause:
DDialog::closeEvent calls done(clickedButtonIndex) using the stale index from the last Confirm button click (1 = QDialog::Accepted). This emits accepted() instead of rejected(), causing dialogAccepted() to fire while dialogCanceled() is never called. As a result, m_inProgress remains true and all subsequent polkit auth requests are rejected with "Another client is already authenticating".

Fix:
1. Add re-entry guard to dialogCanceled() to prevent double cleanup
2. Change dialogFinished() to call dialogCanceled() whenever m_inProgress is still true, acting as a safety net for any close method
3. Add null-pointer protection to dialogAccepted() to prevent accessing cleaned-up session/dialog objects from stale accepted() signals

fix: 修复锁定后通过标题栏关闭按钮关闭鉴权对话框导致无法再次弹出的问题

问题：
输入错误密码至账户锁定后，通过标题栏关闭按钮(X)关闭 polkit 鉴权对话框，
再次触发鉴权时对话框无法弹出。

根因：
DDialog::closeEvent 使用残留的 clickedButtonIndex（确认按钮索引1=Accepted） 调用 done()，导致发出 accepted() 而非 rejected() 信号。dialogCanceled() 从未 被调用，m_inProgress 卡死为 true，后续所有鉴权请求被拦截。

修复：
1. dialogCanceled() 添加 m_inProgress 重入保护，防止重复清理
2. dialogFinished() 改为兜底处理，m_inProgress 为 true 时统一调用 dialogCanceled()
3. dialogAccepted() 添加空指针保护，防止残留信号访问已清理的对象

影响范围：
1. 验证输入错误密码至锁定后点击X关闭，再次开启开关能正常弹出鉴权框
2. 验证点击取消按钮关闭后再次开启正常
3. 验证正常鉴权流程不受影响

PMS: BUG-357469

## Summary by Sourcery

Ensure PolicyKit authentication dialogs always clean up state correctly when closed, preventing them from becoming permanently blocked after certain close paths.

Bug Fixes:
- Prevent the polkit authentication dialog from remaining permanently blocked if the user closes it via non-standard paths such as the window title bar close button.

Enhancements:
- Harden dialog lifecycle handling by guarding against re-entrant cancellation and ignoring stale accepted signals when the authentication session or dialog has already been cleaned up.